### PR TITLE
modName and  funcName should be literals

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -188,8 +188,8 @@ document.
 {
   kind: 'import',
   id: <literal> | <identifier> | null,
-  modName: <literal> | <identifier> | null,
-  funcName: <literal> | <identifier> | null,
+  modName: <literal>,
+  funcName: <literal>,
   params: [ <expr> ]
 }
 ```


### PR DESCRIPTION
I think modName and  funcName should be literals here
